### PR TITLE
Agrega funcionalidad de logs parametrizable por repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.yml
 *.crt
 *.cer
 *.pem
+*.log

--- a/example.py
+++ b/example.py
@@ -3,6 +3,8 @@
 
 import argparse
 import yaml
+import logging
+import logging.config
 import traceback
 from repos import *
 
@@ -46,6 +48,12 @@ if __name__ == "__main__" :
     #TODO: validar errores en el config.yml. hay que asegurar que exista todo lo necesario.
     # Ejemplo: url, params, apikey, etc.
     # Y que exista una clase llamada como en el config.yml
+
+    # FIXME: Deberia borrar esto porque fue una prueba
+    # # Cargamos el diccionario
+    #logging.config.dictConfig((cfg['params'])['logs'])
+    # # Creamos el logger definido en el archivo de configuraci�n
+    #logger = logging.getLogger('Logger_Example')
 
     print("Cargando clases de repositorios")
     #repos = [ 'ieee', 'scopus' ]

--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -2,6 +2,8 @@
 # -*- coding: utf8
 
 import requests
+import logging
+import logging.config
 import pandas as pd
 from abc import ABC, abstractmethod
 
@@ -22,7 +24,13 @@ class repo(ABC):
         self.add_query_param(self.apikey,'apikey')
         self.add_query_param('25','max_records_per_page')
         self.articles_dataframe = pd.DataFrame(columns=["Title", "Found in", "Year"])
-         
+        
+        # Config de Logs
+        logging.config.dictConfig(self.config_params['logs'])
+        if "logger" in repo_params:
+            self.logger = logging.getLogger(repo_params['logger'])
+        else:
+            self.logger = logging.getLogger('root')
 
     @abstractmethod
     def build_dictionary(self):
@@ -73,7 +81,7 @@ class repo(ABC):
         pass
 
     def debug_enabled(self):
-        print("DEBUG: " + str(self.debug))
+        self.logger.debug(str(self.debug))
         return self.debug
 
     def add_to_dataframe(self,title:str="", year:str=""):
@@ -82,7 +90,7 @@ class repo(ABC):
 
 
     def say_hello(self):
-        print("Hola! Soy " + type(self).__name__)
+        self.logger.debug("Hola! Soy " + type(self).__name__)
 
     def export_csv(self):
         self.articles_dataframe.to_csv('table_articles.csv', encoding='utf-8')

--- a/repos/ieee_def.py
+++ b/repos/ieee_def.py
@@ -7,7 +7,7 @@ class ieee(abc_def.repo):
     '''This is a docstring. I have created a new class'''
     def __init__(self, repo_params:dict, config_params:dict, debug:bool=False):
         super().__init__(repo_params, config_params, debug)
-        print(self.url)
+        self.logger.debug(self.url)
 
     def build_dictionary(self):
         self.dictionary['default'] = 'meta_data'
@@ -20,23 +20,25 @@ class ieee(abc_def.repo):
 
     def search(self):
         '''Búsqueda e'''
-        print("Do real searching in repo...")
-        print("DEBUG: " + str(self.query_params))
+        self.logger.info("Do real searching in repo...")
+        self.logger.debug(str(self.query_params))
         ans = requests.get(self.url,params=self.query_params, verify=self.get_config_param('validate-certificate'))
-        print("DEBUG: " + ans.url)
+        self.logger.debug(ans.url)
         records_per_page = int(self.query_params[self.dictionary['max_records_per_page']])
         
         if self.debug_enabled():
-            print("Limitando cantidad de registros")
+            self.logger.warning("Debug activado: Limitando cantidad de registros")
             total_records_count = records_per_page*3
         else:
+            #self.logger.debug(ans)
+            # FIXME: Hay que agregar un manejo de excepciones aca. La linea siguiente falla si se alcanza el limite diario de fetching
             total_records_count = ans.json()['total_records']
 
         for art in range(int(total_records_count)):
             if art and art%records_per_page == 0:
                 self.add_query_param(str(art),'first_index')
                 ans = requests.get(self.url,params=self.query_params, verify=self.get_config_param('validate-certificate'))
-                print("DEBUG: " + ans.url)
+                self.logger.debug(ans.url)
             #print("Debug:" + str(art) + " of " + str(ans.json()['total_records']))
             #print(' - ' + ans.json()['articles'][art%records_per_page]['title'])
             self.add_to_dataframe(ans.json()['articles'][art%records_per_page]['title'], ans.json()['articles'][art%records_per_page]['publication_year'])

--- a/repos/scopus_def.py
+++ b/repos/scopus_def.py
@@ -6,7 +6,7 @@ from . import abc_def
 class scopus(abc_def.repo):
     def __init__(self, repo_params:dict, config_params:dict, debug:bool=False):
         super().__init__(repo_params, config_params, debug)
-        print(self.url)
+        self.logger.debug(self.url)
 
     def build_dictionary(self):
         self.dictionary['default'] = 'query'
@@ -19,23 +19,24 @@ class scopus(abc_def.repo):
 
     def search(self):
         '''Búsqueda e'''
-        print("Do real searching in repo...")
-        print("DEBUG: " + str(self.query_params))
+        self.logger.info("Do real searching in repo...")
+        self.logger.debug(str(self.query_params))
         ans = requests.get(self.url,params=self.query_params, verify=self.get_config_param('validate-certificate'))
-        print("DEBUG: " + ans.url)
+        self.logger.debug(ans.url)
         records_per_page = int(self.query_params[self.dictionary['max_records_per_page']])
 
         if self.debug_enabled():
-            print("Limitando cantidad de registros")
+            self.logger.warning("Debug activado: Limitando cantidad de registros")
             total_records_count = records_per_page*3
         else:
+            # TODO: contemplar que pasa si la busqueda no produce resultados o si se alcanza el limite diario
             total_records_count = ans.json()['search-results']['opensearch:totalResults']
 
         for art in range(int(total_records_count)):
             if art and art%records_per_page == 0:
                 self.add_query_param(str(art),'first_index')
                 ans = requests.get(self.url,params=self.query_params, verify=self.get_config_param('validate-certificate'))
-                print("DEBUG: " + ans.url)
+                self.logger.debug(ans.url)
             #print("Debug:" + str(art) + " of " + str(ans.json()['total_records']))
             #print(' - ' + ans.json()['articles'][art%records_per_page]['title'])
             self.add_to_dataframe(ans.json()['search-results']['entry'][art%records_per_page]['dc:title'],

--- a/template_config.yml
+++ b/template_config.yml
@@ -3,12 +3,34 @@ repos:
     url: 'https://ieeexploreapi.ieee.org/api/v1/search/articles?parameter'
     apikey: WRITE YOUR API KEY HERE!
     enabled: true
+    logger: 'ieee'
 
   scopus:
     url: 'https://api.elsevier.com/content/search/scopus?httpAccept=application/json'
     apikey: WRITE YOUR API KEY HERE!
     enabled: true
+    logger: 'default'
 
 params:
   #validate-certificate: false
   dummy: Another useful params incoming...
+  logs:
+    version: 1
+    formatters:
+      simple:
+        format: "%(asctime)s - %(name)s - %(levelname)s: [%(module)s] %(message)s"
+    handlers:
+      console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+    loggers:
+      default:
+        level: DEBUG
+        handlers:
+        - console
+        propagate: 'no'
+    root:
+      level: NOTSET
+      handlers: []

--- a/template_config.yml
+++ b/template_config.yml
@@ -3,7 +3,7 @@ repos:
     url: 'https://ieeexploreapi.ieee.org/api/v1/search/articles?parameter'
     apikey: WRITE YOUR API KEY HERE!
     enabled: true
-    logger: 'ieee'
+    logger: 'default'
 
   scopus:
     url: 'https://api.elsevier.com/content/search/scopus?httpAccept=application/json'


### PR DESCRIPTION
@bassimat

Estuve trabajando en este tema que me parecía que era el más fácil, creo que ya lo tengo listo. Estaría bueno que hagamos una revisión conjunta de su funcionamiento y ver si se le puede mejorar algo.

Mientras lo iba haciendo me surgieron dudas sobre cómo encararlo y encontré una forma de hacer que todos los repos tengan un logger configurable independiente por medio del archivo de configuración. Es decir, gracias a las prestaciones de logging, ahora se puede definir que la búsqueda en IEEE tenga parámetros o características diferentes a las de Scopus, por ejemplo. Las configuraciones de parámetros de logs quedaron dentro de `params`, y en `repos` agregué un parámetro `logger` para indicar cuál usar. Dejé un ejemplo de esto en el template.

Dejo un ejemplo de ejecución. Ofusqué la url y las apikey por seguridad

```
$ ./example.py --debug xai
El debug esta habilitado
Cargando archivo de configuración
Cargando clases de repositorios
2023-03-20 20:29:36,072 - default - DEBUG: [scopus_def] {MASKED}
2023-03-20 20:29:36,072 - default - DEBUG: [abc_def] Hola! Soy scopus
2023-03-20 20:29:36,072 - default - INFO: [scopus_def] Do real searching in repo...
2023-03-20 20:29:36,073 - default - DEBUG: [scopus_def] {'apikey': '{MASKED}', 'count': '25', 'query': 'xai', 'date': None, 'title': None}
2023-03-20 20:29:36,841 - default - DEBUG: [scopus_def] {MASKED}&count=25&query=xai
2023-03-20 20:29:36,842 - default - DEBUG: [abc_def] True
2023-03-20 20:29:36,842 - default - WARNING: [scopus_def] Debug activado: Limitando cantidad de registros
2023-03-20 20:29:37,736 - default - DEBUG: [scopus_def] {MASKED}&count=25&query=xai&start=25
2023-03-20 20:29:38,818 - default - DEBUG: [scopus_def] {MASKED}&count=25&query=xai&start=50
Fin de ejecución
```
