### PR TITLE
Bugfix: Convergencia de dataframes para exportar a csv

### DIFF
--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -12,6 +12,9 @@ class repo(ABC):
     '''
         Abstract class for repository definition.
     '''
+    articles_fn = 'table_articles.csv'
+    articles_df = pd.DataFrame(columns=["Title", "Found in", "Year"])
+
     def __init__(self, repo_params:dict, config_params:dict, debug:bool=False):
         self.url = repo_params['url']
         self.apikey = repo_params['apikey']
@@ -93,5 +96,6 @@ class repo(ABC):
         self.logger.debug("Hola! Soy " + type(self).__name__)
 
     def export_csv(self):
-        self.articles_dataframe.to_csv('table_articles.csv', encoding='utf-8')
-        #print("Soy " + type(self).__name__+ ", pero aun no se exportar a CSV! Toy chiquito :3")
+        self.logger.info("{} articles exported".format(len(self.articles_dataframe)))
+        repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
+        repo.articles_df.to_csv(repo.articles_fn, encoding='utf-8')

--- a/repos/ieee_def.py
+++ b/repos/ieee_def.py
@@ -25,21 +25,23 @@ class ieee(abc_def.repo):
         ans = requests.get(self.url,params=self.query_params, verify=self.get_config_param('validate-certificate'))
         self.logger.debug(ans.url)
         records_per_page = int(self.query_params[self.dictionary['max_records_per_page']])
-        
+        total_records_count = ans.json()['total_records']
+
         if self.debug_enabled():
             self.logger.warning("Debug activado: Limitando cantidad de registros")
-            total_records_count = records_per_page*3
-        else:
+            # FIXME: En caso de debug total_records_count quedaba en 75 cuando total_records era menor, por lo tanto: "IndexError: list index out of range"
+            total_records_count = min( records_per_page*3, ans.json()['total_records'] )
+        #else:
             #self.logger.debug(ans)
             # FIXME: Hay que agregar un manejo de excepciones aca. La linea siguiente falla si se alcanza el limite diario de fetching
-            total_records_count = ans.json()['total_records']
+            #total_records_count = ans.json()['total_records']
 
         for art in range(int(total_records_count)):
             if art and art%records_per_page == 0:
                 self.add_query_param(str(art),'first_index')
                 ans = requests.get(self.url,params=self.query_params, verify=self.get_config_param('validate-certificate'))
                 self.logger.debug(ans.url)
-            #print("Debug:" + str(art) + " of " + str(ans.json()['total_records']))
+            #print("Debug:" + str(art) + " of " + str(total_records_count) + "/" + str(ans.json()['total_records']) + " -- index: " + str(art%records_per_page) )
             #print(' - ' + ans.json()['articles'][art%records_per_page]['title'])
             self.add_to_dataframe(ans.json()['articles'][art%records_per_page]['title'], ans.json()['articles'][art%records_per_page]['publication_year'])
         self.export_csv()


### PR DESCRIPTION
Se declara un dataframe estático (o a nivel de clase repo) donde cada uno de los repositorios particulares puedas agregar los resultados de búsqueda y así exportar una lista general de los articulos sin pisar los anteriores.
Además, se modifica la lógica de cantidad total de registros en el caso de ieee ya que desbordaba el índice en caso de debug.