### PR TITLE
Corrige búsqueda en scopus al usar parámetros convencionales de ejecución

### DIFF
--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -106,7 +106,10 @@ class repo(ABC):
         self.logger.debug("Hola! Soy " + type(self).__name__)
 
     def export_csv(self):
-        self.logger.info("{} articles exported".format(len(self.articles_dataframe)))
-        repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
+        # Era un repo mas viejecito (1.3.4) y me olvide como hacer appends...
+        # repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
+        # Mejor recurrir a una version mas joven (2.0.0)
+        repo.articles_df = pd.concat( [repo.articles_df, self.articles_dataframe], ignore_index=True, verify_integrity=False )
         repo.articles_df.to_csv(repo.articles_fn, encoding='utf-8')
+        self.logger.info("{} articles exported".format(len(self.articles_dataframe)))
         # print("Soy " + type(self).__name__+ ", pero aun no se exportar a CSV! Toy chiquito :3")


### PR DESCRIPTION
Armo este pull request para debatir mis cambios. Logré resolver el problema de la búsqueda de scopus. Ahora funciona bien tanto si se busca por --query como si se usan los argumentos --title y --from-year. La línea de ejecución que usé para probarlo fue `python .\querier.py --title "xai" --abstract "xai" --from-year 2015 `. Contrasté los resultados de esta búsqueda utilizando el buscador interactivo que hay para probar la api: https://dev.elsevier.com/scopus.html#!/Scopus_Search/ScopusSearch

Sin embargo, me saltó un problema y necesito de tu asistencia. Al intentar exportar el Dataframe, me devuelve este Traceback:

```
2023-06-30 21:09:45,376 - default - INFO: [abc_def] 10 articles exported
Traceback (most recent call last):
  File "D:\ArchivosPersonales\Workspace\repository-reviewer\querier.py", line 66, in <module>
    id.search()
  File "D:\ArchivosPersonales\Workspace\repository-reviewer\repos\scopus_def.py", line 103, in search
    self.export_csv()
  File "D:\ArchivosPersonales\Workspace\repository-reviewer\repos\abc_def.py", line 110, in export_csv
    repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
  File "D:\ArchivosPersonales\Workspace\repository-reviewer\venv\lib\site-packages\pandas\core\generic.py", line 5989, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'append'
Fin de ejecución
```

¿Tenés idea qué puede estar pasando? Creo que está relacionado a lo que habías estado viendo de cómo exportar el .csv.

Por si sirve para el análisis, estoy usando esta versión de pandas.

```
>>> pandas.__version__
'2.0.0'
```