### PR TITLE
Feature de registro historico de búsquedas

### DIFF
--- a/docs/historic.wsd
+++ b/docs/historic.wsd
@@ -1,0 +1,42 @@
+@startuml
+
+package historic{
+  Report --o Search
+  History "1  " o-- "0.." Search
+}
+
+Querier o-- Repo
+Querier o-- History
+Repo --> Report
+
+
+class Repo {
+ ~search(): Report
+}
+
+class Querier
+
+class historic.History {
+ -
+ +Add( Search )
+ +Get( id )
+ +Get( index )
+ +Get( strMatch )
+}
+
+class historic.Report{
+ -counter
+ -timeStats
+ #print()
+}
+
+class historic.Search {
+ - id
+ - results
+ - stringParams
+ - reportData
+ +readResults()
+ +report()
+ +tag()
+}
+@enduml

--- a/historic/__init__.py
+++ b/historic/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["history", "search", "report"]

--- a/historic/__init__.py
+++ b/historic/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["history", "search", "report"]
+__all__ = ["report", "history", "search"]

--- a/historic/history.py
+++ b/historic/history.py
@@ -1,21 +1,108 @@
 #!/usr/bin/python3
 # -*- coding: utf8
-
-from historic.search import Search
+import traceback
+import pandas as pd
+from os import path
+from historic.search import *
 
 class History:
 
-    def __init__(self):
-        raise NotImplemented("Revisar los atributos necesarios para inicializar la clase")
+    GLOBAL_RESULTS_FILENAME = 'results\\history.csv'
+    __df = None
 
-    def Add(self, search:Search):
-        raise NotImplemented("Recibe un registro de busqueda y lo guarda en el historial")
+    def Data( force_loading:bool=False ) -> pd.DataFrame:
+        if (History.__df is None) or force_loading:
+            History.__df = History.__load_dataframe()
+        return History.__df
 
-    def Get(self, id):
-        raise NotImplemented("Recuperar un registro con el tiempo de la busqueda -hhmmss u otros")
 
-    def Get(self, index):
-        raise NotImplemented("Recuperar un registro con el indice que indica cuantas busquedas atras se ha realizado")
+    def Add(search:Search):
+        df_list = [ pd.DataFrame( search.to_dict_format(True) ).set_index('ID') ]
+        try:    df_list.append( History.Data() )
+        except: pass
+        df = pd.concat( df_list )
+        try:# to compute the sum of occurreces in each repo after receiving the last
+            reorder = False
+            cols = df.columns.to_list()
+            if 'Total' not in cols:
+                cols.insert( 0, 'Total' )
+                reorder = True
+            adding_df = df[ cols[ 1 : cols.index('Time Period') ] ]
+            df['Total'] = adding_df.fillna( 0 ).astype( int ).sum( axis=1 ).astype( int )
+            if reorder: df = df.loc[ :, cols ]
+        except: pass
+        df.to_csv( History.GLOBAL_RESULTS_FILENAME, sep=Report.separator, encoding='utf-8')
 
-    def Get(self, str_match):
-        raise NotImplemented("Recuperar un registro con un string que matchee el contenido del registro")
+
+    def Get(value=0):
+        """This is a common function to call the specific overload one.
+        It calls the choosen one by the atribute type or value."""
+        if isinstance(value, list):     return History.Get_by_filter( value )
+        elif isinstance(value, str):    return History.Get_by_matching( value )
+        elif isinstance(value, int):
+            if value > 1000:            return History.Get_by_id( value )
+            elif value < 0:             return History.Get_by_index( value )
+            else:                       return History.Get_previous( value )
+
+    def Get_by_id(id:int) -> pd.Series:
+        return History.Data().loc[ id ]
+
+    def Get_by_filter(filter:list) -> pd.DataFrame:
+        return History.Data()[ filter ]
+
+    def Get_previous(index:int=0) -> pd.Series:
+        """Return the historic register that was searched `index` times ago.
+        The value of `index` must be greater or equal to 0, lower than 1000"""
+        if index < 0: raise ValueError(
+            'The value of `index` must be greater or equal to 0, lower than 1000')
+        return History.Data().iloc[ index ]
+
+    def Get_by_index(index:int) -> pd.Series:
+        """Return the historic register with the index counting from the beginning.
+        The value of `index` must be negative."""
+        if index >= 0:
+            raise ValueError('The value of `index` must be negative')
+        return History.Data().iloc[ index ]
+
+    def Get_by_matching(match:str, field_names:list=[]) -> pd.Series:
+        """Return the historic register whose fields match with the given argument
+        If `field_names` argument is passed it only search on that field/s. If not, the search
+        secuence will start by "Tags" and "Search Params" fields, and then others"""
+        df = History.Data()
+        matching_rows = [False] * df.index.size
+        explicit_search = True
+        if len(field_names) == 0:
+            explicit_search = False
+            field_names = ['Tags','Search Params']
+        # It first search on the selected field names
+        for field in field_names:
+            searching_series:pd.Series = df[ field ]
+            matching_rows |= searching_series.str.contains( match ).values
+        if (True in matching_rows) or (explicit_search == True):
+            return History.Get_by_filter( matching_rows )
+        # If not match yet, then search on the others fields starting backwards
+        for field in reversed( df.columns.drop(field_names) ):
+            searching_series:pd.Series = df[ field ]
+            matching_rows = searching_series.str.contains( match ).values
+            if (True in matching_rows):
+                break
+        return History.Get_by_filter( matching_rows )
+
+
+    def Filter_date( d_from:str=None, d_to:str=None) -> list:
+        df = History.Data()
+        filter = [True] * df.index.size
+        id_len = len( Search.ID_Format )
+        # Verify dates input are not formated
+        if d_from:
+            filter &= df.index > int( d_from.ljust(id_len,'0') )
+        if d_to:
+            filter &= df.index < int( d_to.ljust(id_len,'0') )
+        return filter
+
+
+    def __load_dataframe() -> pd.DataFrame:
+        df = pd.read_csv( History.GLOBAL_RESULTS_FILENAME, sep=Report.separator, index_col='ID')
+        df = df.fillna('')
+        return df
+

--- a/historic/history.py
+++ b/historic/history.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+# -*- coding: utf8
+
+from search import Search
+
+class History:
+
+    def __init__(self):
+        raise NotImplemented("Revisar los atributos necesarios para inicializar la clase")
+
+    def Add(self, search:Search):
+        raise NotImplemented("Recibe un registro de busqueda y lo guarda en el historial")
+
+    def Get(self, id):
+        raise NotImplemented("Recuperar un registro con el tiempo de la busqueda -hhmmss u otros")
+
+    def Get(self, index):
+        raise NotImplemented("Recuperar un registro con el indice que indica cuantas busquedas atras se ha realizado")
+
+    def Get(self, str_match):
+        raise NotImplemented("Recuperar un registro con un string que matchee el contenido del registro")

--- a/historic/history.py
+++ b/historic/history.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # -*- coding: utf8
 
-from search import Search
+from historic.search import Search
 
 class History:
 

--- a/historic/report.py
+++ b/historic/report.py
@@ -4,6 +4,7 @@
 def get_min_and_max(array) -> tuple:
     min = max = array[0]
     for item in array:
+        if type(item) is not int: item = int(item[:4])
         if (min > item):
             min = item
         if (max < item):
@@ -50,7 +51,7 @@ class Report:
         occur = self._occurrences
         total = occur if type(occur) == int else occur[0]
         for cont in self._time_div_cont:
-            self._time_div_perc.append( 100*cont/total )
+            self._time_div_perc.append( 0 if (total == 0) else (100*cont/total) )
         return self
 
 
@@ -123,6 +124,8 @@ class Report:
         # Distribute all the items in each division by making a recount.
         for y in years:
             for i in range(TIME_DIVISIONS):
+                if type(y) is not int:
+                    y = int(y[:4])
                 if y <= div_limits[i]:
                     div_counts[i] += 1
                     break
@@ -161,6 +164,10 @@ class Report:
             elif item in ['_occurrences', '_time_div_perc']:
                 continue
             elif item == '_time_div_cont':
+                #out_str += "From" + Report.separator       ## TODO: cambiar a header generico
+                #for i in range(TIME_DIVISIONS):
+                #    out_str += "-"+str(i)+"-" + Report.separator
+                #out_str += "To" + Report.separator
                 out_str += str(Report.__time_period[0]) +"-"
                 for i,t in enumerate( self._get_periods_arrays(Report.__time_period)[0] ):
                     if i == 0: out_str += str(int(t))[-2:] + Report.separator

--- a/historic/report.py
+++ b/historic/report.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+# -*- coding: utf8
+
+def get_min_and_max(array) -> tuple:
+    min = max = array[0]
+    for item in array:
+        if (min > item):
+            min = item
+        if (max < item):
+            max = item
+    return (min, max)
+
+TIME_DIVISIONS = 3
+
+
+class Report:
+
+    def __init__(self):
+        pass 
+                 
+                 
+    def process_dates(self, publication_dates):
+        time_span = get_min_and_max(publication_dates)
+        self._occurrences = len(publication_dates)
+        self._time_div_cont = self._process_dates_distribution(publication_dates, time_span)
+
+ 
+    def calculate_percentages(self):
+        self._time_div_perc = []
+        for cont in self._time_div_cont:
+            self._time_div_perc.append( 100*cont/self._occurrences )
+
+
+    def _process_dates_distribution(self, years, span:tuple):
+        div_span = (span[1] - span[0]) / TIME_DIVISIONS
+        div_limits = [span[0] + div_span]
+        div_counts = [0]
+        # Establece los limites superiores de cada division de tiempo
+        for i in range(1,TIME_DIVISIONS):
+            div_limits.append( div_limits[-1] + div_span )
+            div_counts.append( 0 )
+        # Reparte todos los articulos en cada division haciendo un recuento
+        for y in years:
+            for i in range(TIME_DIVISIONS):
+                if y < div_limits[i]:
+                    div_counts[i] += 1
+                    break
+        return div_counts

--- a/historic/report.py
+++ b/historic/report.py
@@ -15,20 +15,93 @@ TIME_DIVISIONS = 3
 
 class Report:
 
-    def __init__(self):
-        pass 
-                 
-                 
-    def process_dates(self, publication_dates):
-        time_span = get_min_and_max(publication_dates)
+    def __init__(self, name):
+        self._name = name
+        self._occurrences = 0 
+        self._time_div_cont = []
+        self._time_div_perc = []
+
+
+    def Import(report_items:dict, name=None):
+        r = Report('imported_report')
+        r.__dict__ = report_items
+        if name: r._name = name
+        return r
+
+
+    def process_dates(self, publication_dates, time_span:tuple=None):
+        """Get an array of all article publication years to count the number of results and get time statistics.
+        It is optional but important to inform the time span of the search period to get accuracy statistics."""
+        if (time_span is None):
+            time_span = get_min_and_max(publication_dates)
         self._occurrences = len(publication_dates)
         self._time_div_cont = self._process_dates_distribution(publication_dates, time_span)
+        return self
 
- 
+
     def calculate_percentages(self):
-        self._time_div_perc = []
+        occur = self._occurrences
+        total = occur if type(occur) == int else occur[0]
         for cont in self._time_div_cont:
-            self._time_div_perc.append( 100*cont/self._occurrences )
+            self._time_div_perc.append( 100*cont/total )
+        return self
+
+
+    def merge_reports(self, other):
+        compound = {}
+         # if the other is the same type (a simple one in this case)
+        if type(other) is Report:
+            # a simple merge can be performed
+            for item in self.__dict__:
+                # string items: appended on a list
+                if item == '_name':
+                    compound[item] = self._merge_str(other, item)
+                # numeric item like _ocurrences: first a totalizator, then individuals
+                elif item == '_occurrences':
+                    compound[item] = self._merge_int(other, item)
+                # merge a list: add values by index
+                elif item.startswith('_time_div'):
+                    compound[item] = self._merge_list(other, item)
+        else:
+            # if not, the other class must know how to merge complex ones
+            return other.merge_reports( self )
+        return Compound_Report.Import( compound )
+
+
+#   Representation methods
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+    def __str__(self) -> str:
+        return str(self.__repl__())
+    
+    def at(self, item_name):
+        return self.__dict__[item_name]
+
+
+#   Private methods
+
+    def _merge_list(self, other, item):
+        merging_list = []
+        for idx in range(len(self.at(item))):
+            merging_list.append( self.at(item)[idx] + other.at(item)[idx] )
+        return merging_list
+    
+
+    def _merge_str(self, other, item):
+        merging_names = ['Total']
+        merging_names.append( self.at(item) )
+        merging_names.append( other.at(item) )
+        return merging_names
+
+
+    def _merge_int(self, other, item):
+        merging_ocurr = []
+        merging_ocurr.append( self.at(item) + other.at(item) )
+        merging_ocurr.append( self.at(item) )
+        merging_ocurr.append( other.at(item) )
+        return merging_ocurr
 
 
     def _process_dates_distribution(self, years, span:tuple):
@@ -46,3 +119,26 @@ class Report:
                     div_counts[i] += 1
                     break
         return div_counts
+
+
+
+class Compound_Report(Report):
+
+    def Import(report_items:dict, name=None):
+        r = Compound_Report('imported_report')
+        r.__dict__ = report_items
+        if name: r._name = name
+        return r
+    
+    def _merge_str(self, other:Report, item):
+        merge_names = self.at(item).copy()
+        merge_names.append( other.at(item) )
+        return merge_names
+
+    def _merge_int(self, other:Report, item):
+        merging_ocurr = []
+        merging_ocurr.append( self.at(item)[0] + other.at(item) )
+        for value in self.at(item)[1:]:
+            merging_ocurr.append( value )            
+        merging_ocurr.append( other.at(item) )
+        return merging_ocurr

--- a/historic/search.py
+++ b/historic/search.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+# -*- coding: utf8
+
+from report import *
+
+class Search:
+
+    def __init__(self, search_params):
+        self._id = ""
+        self._results = "???"
+        self._search_params = search_params
+        self._report_data = None
+
+
+    def read_search_partial( result:Report ):
+        pass
+
+
+    def report() -> Report:
+        pass
+
+
+    def tag( string_tag ):
+        pass

--- a/historic/search.py
+++ b/historic/search.py
@@ -38,7 +38,6 @@ class Search:
             self._report_data = results
         else:
             self._report_data = self._report_data.merge_reports( results )
-        print(self._report_data)
 
 
     def report(self) -> Report:
@@ -55,11 +54,12 @@ class Search:
 
 
     def __str__(self) -> str:
-        return self._export_to_csv(with_header=True)
+        return self._print_with_csv_format(with_header=True)
 
 
-    def _export_to_csv(self, with_header:bool=False) -> str:
+    def _print_with_csv_format(self, with_header:bool=False) -> str:
         line = self._id + Report.separator
+        if self._report_data is None: return ''
         head_with_data = str(self._report_data).split(sep='\n')
         line += head_with_data[1] + Report.separator
         for tag in self._tags:

--- a/historic/search.py
+++ b/historic/search.py
@@ -9,10 +9,10 @@ from datetime import datetime
 class Search:
 
     RESULTS_BASE_FILENAME = 'results\\articles_table.csv'
+    ID_Format = "%y%m%d%H%M%S"
 
     def __init__(self, search_params:dict):
-        frmat_id = "%y%m%d%H%M%S"
-        self._id = datetime.now().strftime(frmat_id)
+        self._id = datetime.now().strftime( Search.ID_Format )
         self._report_data = None
         self._tags = []
         self._search_params = search_params
@@ -54,22 +54,39 @@ class Search:
 
 
     def __str__(self) -> str:
-        return self._print_with_csv_format(with_header=True)
+        return '\n'.join( self.to_csv_lines(with_header=True) )
 
 
-    def _print_with_csv_format(self, with_header:bool=False) -> str:
+    def to_csv_lines(self, with_header:bool=False) -> list:
         line = self._id + Report.separator
-        if self._report_data is None: return ''
-        head_with_data = str(self._report_data).split(sep='\n')
+        if self.report() is None: return ''
+        head_with_data = str(self.report()).split(sep='\n')
         line += head_with_data[1] + Report.separator
         for tag in self._tags:
             line += " #"+ tag
         else: line += Report.separator
         line += str(self._search_params) + Report.separator
 
+        result = []
         if with_header:
             header = 'ID' + Report.separator + head_with_data[0] + Report.separator
             header+= 'Tags' + Report.separator
             header+= 'Search Params' + Report.separator
-            line = header[:-len(Report.separator)] + '\n' + line
-        return line[:-len(Report.separator)] + '\n'
+            result.append( header[:-len(Report.separator)] )
+        result.append( line[:-len(Report.separator)] )
+        return result
+
+    def to_dict_format(self, for_dataFrame:bool=False) -> dict:
+        if self.report() is None:
+            return ''
+        di = dict()
+        h_and_d = self.to_csv_lines(with_header=True)
+        header_l = h_and_d[0].split(';')
+        data_list = h_and_d[1].split(';')
+        if for_dataFrame:
+            for (title, value) in zip( header_l, data_list ):
+                di[title] = [value]
+        else:
+            for (title, value) in zip( header_l, data_list ):
+                di[title] = value
+        return di

--- a/historic/search.py
+++ b/historic/search.py
@@ -1,24 +1,27 @@
 #!/usr/bin/python3
 # -*- coding: utf8
 
-from report import *
+from historic.report import *
 
 class Search:
 
     def __init__(self, search_params):
-        self._id = ""
+        self._id = "yymmddhhmmss"
         self._results = "???"
         self._search_params = search_params
         self._report_data = None
 
 
-    def read_search_partial( result:Report ):
-        pass
+    def read_search_partial(self, results:Report):
+        if (self._report is None):
+            self._report_data = results
+        else:
+            self._report_data.merge_reports( results )
 
 
-    def report() -> Report:
-        pass
+    def report(self) -> Report:
+        return str(self._report_data)
 
 
-    def tag( string_tag ):
-        pass
+    def tag(self, string_tag):
+        raise NotImplemented("Debe agregar una etiqueta a este registro de busqueda")

--- a/historic/search.py
+++ b/historic/search.py
@@ -1,22 +1,44 @@
 #!/usr/bin/python3
 # -*- coding: utf8
 
+from os import path
 from historic.report import *
+from datetime import datetime
+
 
 class Search:
 
-    def __init__(self, search_params):
-        self._id = "yymmddhhmmss"
-        self._results = "???"
-        self._search_params = search_params
+    RESULTS_BASE_FILENAME = 'results\\articles_table.csv'
+
+    def __init__(self, search_params:dict):
+        frmat_id = "%y%m%d%H%M%S"
+        self._id = datetime.now().strftime(frmat_id)
         self._report_data = None
+        self._tags = []
+        self._search_params = search_params
+        self._fn = None
 
 
-    def read_search_partial(self, results:Report):
-        if (self._report is None):
+    def get_result_filename(self) -> str:
+        """If filename has already been set, return it. If not, takes the base filename,
+        insert the time id before the extension and check if the file exist to return it.
+        Returns None if the file does not exist"""
+        if self._fn:
+            return self._fn
+        fn = Search.RESULTS_BASE_FILENAME.split(sep='.')
+        fn.insert( 1, "_"+ self._id +"." )
+        fn = ''.join(fn)
+        if path.isfile( fn ):
+            self._fn = fn
+        return self._fn
+
+
+    def append_partial_res(self, results:Report):
+        if (self._report_data is None):
             self._report_data = results
         else:
-            self._report_data.merge_reports( results )
+            self._report_data = self._report_data.merge_reports( results )
+        print(self._report_data)
 
 
     def report(self) -> Report:
@@ -24,4 +46,30 @@ class Search:
 
 
     def tag(self, string_tag):
-        raise NotImplemented("Debe agregar una etiqueta a este registro de busqueda")
+        self._tags.append(string_tag)
+
+
+    def __repr__(self) -> str:
+        representacion_interpretable = '{self.__class__.__name__}({self.__dict__})'.format(self=self)
+        return representacion_interpretable
+
+
+    def __str__(self) -> str:
+        return self._export_to_csv(with_header=True)
+
+
+    def _export_to_csv(self, with_header:bool=False) -> str:
+        line = self._id + Report.separator
+        head_with_data = str(self._report_data).split(sep='\n')
+        line += head_with_data[1] + Report.separator
+        for tag in self._tags:
+            line += " #"+ tag
+        else: line += Report.separator
+        line += str(self._search_params) + Report.separator
+
+        if with_header:
+            header = 'ID' + Report.separator + head_with_data[0] + Report.separator
+            header+= 'Tags' + Report.separator
+            header+= 'Search Params' + Report.separator
+            line = header[:-len(Report.separator)] + '\n' + line
+        return line[:-len(Report.separator)] + '\n'

--- a/querier.py
+++ b/querier.py
@@ -17,7 +17,7 @@ parser.add_argument('--abstract', dest='abstract', type=str, required=False)
 parser.add_argument('--from-year', dest='fromYear', type=str, required=False)
 parser.add_argument('--to-year', dest='toYear', type=str, required=False)
 parser.add_argument('--query', dest='query', type=str, required=False)
-parser.add_argument('--content', dest='content', type=str, required=False) # por qué no dejarlo por como input sin argumento?
+parser.add_argument('--content', dest='content', type=str, required=False)
 
 
 def read_yaml(file_path):
@@ -30,7 +30,6 @@ if __name__ == "__main__" :
     if args.debug:
         print("El debug esta habilitado")
         __debug_flag = True
-        print("ARGUMENTS:\n", args.__dict__)
     else:
         __debug_flag = False
 
@@ -43,7 +42,6 @@ if __name__ == "__main__" :
 
     search_handler = search.Search( args.__dict__ )
 
-    print("Cargando clases de repositorios")
     for repo in cfg['repos'].keys():
         try:
             # La línea siguiente invoca a la clase dentro del package.
@@ -55,7 +53,6 @@ if __name__ == "__main__" :
                         id.add_query_param(args.content, 'content')
                         id.add_query_param(args.fromYear, 'from_year')
                         id.add_query_param(args.title, 'title')
-                        # porque no se agrega el resto de argumentos?
                         id.add_query_param(args.toYear , 'to_year')
                         id.add_query_param(args.abstract , 'abstract')
                     else:
@@ -67,7 +64,4 @@ if __name__ == "__main__" :
         except Exception:
             traceback.print_exc()
     #del repos
-
-    print("\n\nHistory Report:")
-    print( str(search_handler) )
-    print("Fin de ejecución")
+    history.History.Add( search_handler )

--- a/querier.py
+++ b/querier.py
@@ -60,6 +60,7 @@ if __name__ == "__main__" :
                         # TODO: Si me funciona con IEEE, tengo que ver cómo hacerlo para scopus.
                         id.load_query(args.query)
                     search_handler.append_partial_res( id.search() )
+                    id.export_csv()
                     del id
         except Exception:
             traceback.print_exc()

--- a/querier.py
+++ b/querier.py
@@ -17,7 +17,7 @@ parser.add_argument('--abstract', dest='abstract', type=str, required=False)
 parser.add_argument('--from-year', dest='fromYear', type=str, required=False)
 parser.add_argument('--to-year', dest='toYear', type=str, required=False)
 parser.add_argument('--query', dest='query', type=str, required=False)
-parser.add_argument('--content', dest='content', type=str, required=False)
+parser.add_argument('--content', dest='content', type=str, required=False) # por qué no dejarlo por como input sin argumento?
 
 
 def read_yaml(file_path):
@@ -51,11 +51,13 @@ if __name__ == "__main__" :
             if cfg['repos'][repo]['enabled'] is True:
                 id = getattr(globals()[repo + '_def'], repo)(cfg['repos'][repo], cfg['params'], __debug_flag)
                 if id is not None:
-                    id.say_hello()
                     if args.query == "" or args.query is None:
                         id.add_query_param(args.content, 'content')
                         id.add_query_param(args.fromYear, 'from_year')
                         id.add_query_param(args.title, 'title')
+                        # porque no se agrega el resto de argumentos?
+                        id.add_query_param(args.toYear , 'to_year')
+                        id.add_query_param(args.abstract , 'abstract')
                     else:
                         # TODO: Si me funciona con IEEE, tengo que ver cómo hacerlo para scopus.
                         id.load_query(args.query)
@@ -66,5 +68,6 @@ if __name__ == "__main__" :
             traceback.print_exc()
     #del repos
 
+    print("\n\nHistory Report:")
     print( str(search_handler) )
     print("Fin de ejecución")

--- a/querier.py
+++ b/querier.py
@@ -30,6 +30,7 @@ if __name__ == "__main__" :
     if args.debug:
         print("El debug esta habilitado")
         __debug_flag = True
+        print("ARGUMENTS:\n", args.__dict__)
     else:
         __debug_flag = False
 
@@ -40,15 +41,9 @@ if __name__ == "__main__" :
     # Ejemplo: url, params, apikey, etc.
     # Y que exista una clase llamada como en el config.yml
 
-    # FIXME: Deberia borrar esto porque fue una prueba
-    # # Cargamos el diccionario
-    #logging.config.dictConfig((cfg['params'])['logs'])
-    # # Creamos el logger definido en el archivo de configuración
-    #logger = logging.getLogger('Logger_Example')
+    search_handler = search.Search( args.__dict__ )
 
     print("Cargando clases de repositorios")
-    #repos = [ 'ieee', 'scopus' ]
-    #print(globals())
     for repo in cfg['repos'].keys():
         try:
             # La línea siguiente invoca a la clase dentro del package.
@@ -64,10 +59,11 @@ if __name__ == "__main__" :
                     else:
                         # TODO: Si me funciona con IEEE, tengo que ver cómo hacerlo para scopus.
                         id.load_query(args.query)
-                    id.search()
+                    search_handler.append_partial_res( id.search() )
                     del id
         except Exception:
             traceback.print_exc()
     #del repos
 
+    print( str(search_handler) )
     print("Fin de ejecución")

--- a/querier.py
+++ b/querier.py
@@ -7,6 +7,7 @@ import logging
 import logging.config
 import traceback
 from repos import *
+from historic import *
 
 # Create the arguments parser
 parser = argparse.ArgumentParser()

--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -5,6 +5,8 @@ import requests
 import logging
 import logging.config
 import pandas as pd
+from historic import *
+from datetime import datetime
 from abc import ABC, abstractmethod
 
 
@@ -110,3 +112,15 @@ class repo(ABC):
         repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
         repo.articles_df.to_csv(repo.articles_fn, encoding='utf-8')
         # print("Soy " + type(self).__name__+ ", pero aun no se exportar a CSV! Toy chiquito :3")
+
+    def build_report(self, publication_dates_array):
+        time_span = None
+        from_year = self.query_params.get( self.dictionary['from_year'] )
+        if from_year is not None:
+            to_year = self.query_params.get( self.dictionary['to_year'] )
+            if to_year is None:
+                to_year = datetime.now().strftime('%Y')
+            time_span = ( int(from_year), int(to_year) )
+        r = report.Report(self.__class__.__name__)
+        r.process_dates( publication_dates_array, time_span)
+        return r

--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -65,7 +65,7 @@ class repo(ABC):
         # TODO: Esto me quedo valido solo para IEEE, tengo que cambiarlo
 
         self.query_params[self.dictionary['query']] = self.parse_query(query)
-        pass
+
 
     def add_query_param(self, value: str, value_type: str) -> None:
         """
@@ -76,8 +76,9 @@ class repo(ABC):
                 - abstract
                 - title
         """
-        self.query_params[self.dictionary[value_type]] = value
-        pass
+        if value is not None:
+            self.query_params[self.dictionary[value_type]] = value
+
 
     def get_config_param(self, name: str):
         """
@@ -118,6 +119,9 @@ class repo(ABC):
 
     def build_report(self, publication_dates_array) -> Report:
         time_span = None
+        if (publication_dates_array is None):
+            method = self.__class__.__name__ +".build_report( )"
+            raise ValueError("On "+method+": publication_dates_array parameter must be a non-empty array")
         from_year = self.query_params.get( self.dictionary['from_year'] )
         if from_year is not None:
             to_year = self.query_params.get( self.dictionary['to_year'] )

--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -126,8 +126,8 @@ class repo(ABC):
         if from_year is not None:
             to_year = self.query_params.get( self.dictionary['to_year'] )
             if to_year is None:
-                to_year = datetime.now().strftime('%Y')
-            time_span = ( int(from_year), int(to_year) )
-        r = Report(self.__class__.__name__)
+                to_year = datetime.now().strftime('%Y-%m-%d')
+            time_span = ( from_year, to_year )
+        r = Report(self.__class__.__name__, self.logger)
         r.process_dates( publication_dates_array, time_span)
         return r

--- a/repos/abc_def.py
+++ b/repos/abc_def.py
@@ -5,7 +5,7 @@ import requests
 import logging
 import logging.config
 import pandas as pd
-from historic import *
+from historic.report import Report
 from datetime import datetime
 from abc import ABC, abstractmethod
 
@@ -93,7 +93,7 @@ class repo(ABC):
     #     pass
 
     @abstractmethod
-    def search(self):
+    def search(self) -> Report:
         pass
 
     def debug_enabled(self):
@@ -108,12 +108,15 @@ class repo(ABC):
         self.logger.debug("Hola! Soy " + type(self).__name__)
 
     def export_csv(self):
-        self.logger.info("{} articles exported".format(len(self.articles_dataframe)))
-        repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
+        # Era un repo mas viejecito (1.3.4) y me olvide como hacer appends...
+        # repo.articles_df = repo.articles_df.append( self.articles_dataframe, ignore_index=True, verify_integrity=False)
+        # Mejor recurrir a una version mas joven (2.0.0)
+        repo.articles_df = pd.concat( [repo.articles_df, self.articles_dataframe], ignore_index=True, verify_integrity=False )
         repo.articles_df.to_csv(repo.articles_fn, encoding='utf-8')
+        self.logger.info("{} articles exported".format(len(self.articles_dataframe)))
         # print("Soy " + type(self).__name__+ ", pero aun no se exportar a CSV! Toy chiquito :3")
 
-    def build_report(self, publication_dates_array):
+    def build_report(self, publication_dates_array) -> Report:
         time_span = None
         from_year = self.query_params.get( self.dictionary['from_year'] )
         if from_year is not None:
@@ -121,6 +124,6 @@ class repo(ABC):
             if to_year is None:
                 to_year = datetime.now().strftime('%Y')
             time_span = ( int(from_year), int(to_year) )
-        r = report.Report(self.__class__.__name__)
+        r = Report(self.__class__.__name__)
         r.process_dates( publication_dates_array, time_span)
         return r

--- a/repos/ieee_def.py
+++ b/repos/ieee_def.py
@@ -69,13 +69,9 @@ class ieee(abc_def.repo):
 
         if self.debug_enabled():
             self.logger.warning("Debug activado: Limitando cantidad de registros")
-            # FIXME: En caso de debug total_records_count quedaba en 75 cuando total_records era menor, por lo tanto: "IndexError: list index out of range"
             total_records_count = min( records_per_page*3, ans.json()['total_records'] )
-        #else:
-            #self.logger.debug(ans)
-            # FIXME: Hay que agregar un manejo de excepciones aca. La linea siguiente falla si se alcanza el limite diario de fetching
-            #total_records_count = ans.json()['total_records']
 
+        pub_year_array = []
         for art in range(int(total_records_count)):
             if art and art%records_per_page == 0:
                 self.add_query_param(str(art),'first_index')
@@ -83,5 +79,8 @@ class ieee(abc_def.repo):
                 self.logger.debug(ans.url)
             #print("Debug:" + str(art) + " of " + str(total_records_count) + "/" + str(ans.json()['total_records']) + " -- index: " + str(art%records_per_page) )
             #print(' - ' + ans.json()['articles'][art%records_per_page]['title'])
-            self.add_to_dataframe(ans.json()['articles'][art%records_per_page]['title'], ans.json()['articles'][art%records_per_page]['publication_year'])
+            pub_year = ans.json()['articles'][art%records_per_page]['publication_year']
+            self.add_to_dataframe(ans.json()['articles'][art%records_per_page]['title'], pub_year)
+            pub_year_array.append( pub_year )
         self.export_csv()
+        return self.build_report(pub_year_array)

--- a/repos/ieee_def.py
+++ b/repos/ieee_def.py
@@ -82,5 +82,4 @@ class ieee(abc_def.repo):
             pub_year = ans.json()['articles'][art%records_per_page]['publication_year']
             self.add_to_dataframe(ans.json()['articles'][art%records_per_page]['title'], pub_year)
             pub_year_array.append( pub_year )
-        self.export_csv()
         return self.build_report(pub_year_array)

--- a/repos/pubmed_def.py
+++ b/repos/pubmed_def.py
@@ -79,10 +79,14 @@ class pubmed(abc_def.repo):
         summ = self.__exec_Summary( results, idxs_dict, use_history=True )
         print("DEBUG: results... ", results )
 
+        pub_year_array = []
         articles = summ[pubmed._p_ids_summary]
         for art in articles:
-            self.add_to_dataframe( summ[art]['title'], date_format(summ[art]['pubdate']) )
+            pub_year = date_format(summ[art]['pubdate'])
+            self.add_to_dataframe( summ[art]['title'], pub_year )
+            pub_year_array.append( pub_year )
         self.export_csv()
+        return self.build_report(pub_year_array)
 
 
     def __exec_eSearch(self, index_constraint:dict=None, use_history=False, db='pubmed') -> dict:

--- a/repos/pubmed_def.py
+++ b/repos/pubmed_def.py
@@ -81,13 +81,12 @@ class pubmed(abc_def.repo):
         pub_years_array = []
         self._map_params_into_terms()
         results = self.__exec_eSearch( idxs_dict, use_history=True )
-        self.logger.debug("Search results: "+ str(results))
+        self.logger.info("Number of articles found: "+ results['count'] )
+        # self.logger.debug("Search results: "+ str(results))
 
-        if results:
-            self.logger.info("Number of articles found: "+ results['count'] )
-
+        if int(results['count']) > 0:
             summ = self.__exec_Summary( results, idxs_dict, use_history=True )
-            self.logger.debug("Summary results: "+ str(summ))
+            # self.logger.debug("Summary results: "+ str(summ))
 
             articles = summ[pubmed._p_ids_summary]
             for art in articles:
@@ -135,10 +134,14 @@ class pubmed(abc_def.repo):
 
     def __validate_pubmed_answer(self, ans, method_result_field:str) -> dict:
         error = res = None
-        if not ans.ok: # Request level error ?
-            error = ans.reason
-        else:          # Search engine level error ?
-            error = ans.json().get( method_result_field ).get('ERROR', False)
+        try:
+            if not ans.ok: # Request level error ?
+                error = ans.reason
+            else:          # Search engine level error ?
+                error = ans.json().get( method_result_field ).get('ERROR', False)
+        except Exception as exc:
+            self.logger.error("On exception, ans: "+ str(ans.__dict__) )
+            error = str( exc )
         if error:
             self.logger.error('on {}: REASON {{{}}}'.format(method_result_field, error) )
         else:

--- a/repos/pubmed_def.py
+++ b/repos/pubmed_def.py
@@ -25,8 +25,8 @@ class pubmed(abc_def.repo):
     _p_query_key_summary = 'query_key'
     _p_WebEnv_search = 'webenv'
     _p_WebEnv_summary = 'WebEnv'
-    _f_ans_result = 'result'
-    _f_fail_result = 'esummaryresult'
+    _f_search_result = 'esearchresult'
+    _f_summary_result = 'result' #'esummaryresult'
 
     '''
     Class to excecute searches in the NCBI (National Center for Biotechnology Information) PubMed database.
@@ -52,43 +52,53 @@ class pubmed(abc_def.repo):
     def build_dictionary(self):
         self.dictionary['content'] = 'term'
         self.dictionary['apikey'] = 'api_key'
-        self.dictionary['title'] = 'title'
         self.dictionary['from_year'] = 'mindate'
         self.dictionary['to_year'] = 'maxdate'
         self.dictionary['max_records_per_page'] = 'retmax'
         self.dictionary['first_index'] = 'retstart'
-        self.dictionary['abstract'] = 'term'    # HACK
-        self.dictionary['keyword'] = 'term'     # HACK
-        self.dictionary['query'] = 'term'       # HACK
+        # Complex terms:
+        self.dictionary['abstract'] = ':[Abstract]->term'
+        self.dictionary['keyword'] = ':[Other Term]->term'
+        self.dictionary['title'] = ':[Title]->term'
+        self.dictionary['query'] = ':->term'
 
 
     def search(self):
         '''Specific method for querying the database.
         For more information see https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch'''
-        print("DEBUG: " + str(self.query_params))
+        self.logger.info("Do real searching in repo...")
+        self.logger.debug("Un processed query_params :" + str(self.query_params))
         
         idxs_dict = None
         if self.debug_enabled():
-            print("Limitando cantidad de registros")
+            self.logger.warning("Debug activado: Limitando cantidad de registros")
             records_per_page = 5 #int(self.query_params[self.dictionary['max_records_per_page']])
             idxs_dict = {
                 'retstart': '0',
                 'retmax': records_per_page
             }            
         
+        pub_years_array = []
+        self._map_params_into_terms()
         results = self.__exec_eSearch( idxs_dict, use_history=True )
-        print("DEBUG: :\n Cant de registros encontrados:", results['count'] )
+        self.logger.debug("Search results: "+ str(results))
 
-        summ = self.__exec_Summary( results, idxs_dict, use_history=True )
-        print("DEBUG: results... ", results )
+        if results:
+            self.logger.info("Number of articles found: "+ results['count'] )
 
-        pub_year_array = []
-        articles = summ[pubmed._p_ids_summary]
-        for art in articles:
-            pub_year = date_format(summ[art]['pubdate'])
-            self.add_to_dataframe( summ[art]['title'], pub_year )
-            pub_year_array.append( pub_year )
-        return self.build_report(pub_year_array)
+            summ = self.__exec_Summary( results, idxs_dict, use_history=True )
+            self.logger.debug("Summary results: "+ str(summ))
+
+            articles = summ[pubmed._p_ids_summary]
+            for art in articles:
+                pub_year = date_format(summ[art]['pubdate'])
+                self.add_to_dataframe( summ[art]['title'], pub_year )
+                pub_years_array.append( pub_year )
+        return self.build_report(pub_years_array)
+
+
+    def parse_query(self, query: str) -> str:
+        self.logger.warning( "\n CUIDADO QUE pubmed.parse_query( ) NO ESTA IMPLEMENTADO pero si en [HACK] !\n")
 
 
     def __exec_eSearch(self, index_constraint:dict=None, use_history=False, db='pubmed') -> dict:
@@ -99,11 +109,7 @@ class pubmed(abc_def.repo):
             specific_params |= index_constraint
 
         ans = requests.get( self.url+pubmed._method_eSearch, params=self.query_params|specific_params, verify=self.get_config_param('validate-certificate'))
-        if not ans.ok:
-            print('ERROR: on __exec_eSearch: not ans.ok. REASON:', ans.reason )
-        else:
-            print('DEBUG: eSearch url', ans.url )
-        return ans.json()['esearchresult']
+        return self.__validate_pubmed_answer( ans, pubmed._f_search_result )
 
 
     def __exec_Summary(self, eSearch_results:dict, index_constraint:dict=None, use_history=False, db='pubmed') -> dict:
@@ -124,20 +130,58 @@ class pubmed(abc_def.repo):
             raise NotImplemented("Escenario no probado: Debe cargar la lista de IDs del eSearch_results en el nuevo GET cuando usehistory=False")
 
         ans = requests.get( self.url+pubmed._method_eSummary, params=self.query_params|specific_params, verify=self.get_config_param('validate-certificate'))
-        if not ans.ok:
-            print('ERROR: on __exec_eSummary: not ans.ok. REASON:', ans.reason )
+        return self.__validate_pubmed_answer( ans, pubmed._f_summary_result )
+
+
+    def __validate_pubmed_answer(self, ans, method_result_field:str) -> dict:
+        error = res = None
+        if not ans.ok: # Request level error ?
+            error = ans.reason
+        else:          # Search engine level error ?
+            error = ans.json().get( method_result_field ).get('ERROR', False)
+        if error:
+            self.logger.error('on {}: REASON {{{}}}'.format(method_result_field, error) )
         else:
-            print('DEBUG: eSummary url:\n', ans.url )
-        try:
-            result = ans.json()[pubmed._f_ans_result]
-        except Exception as exc:
-            result = ans.json()[pubmed._f_fail_result]
-            print('ERROR: returning\n', result )
-            print('DEBUG: ans.text', ans.text)
-            print( exc )
-            return None
-        return result
+            self.logger.debug(method_result_field +' url:'+ str(ans.url) )
+            res = ans.json().get( method_result_field )
+        return res
 
 
-    def parse_query(self, query: str) -> str:
-        self.logger.warning( "\n CUIDADO QUE pubmed.parse_query( ) NO ESTA IMPLEMENTADO pero si en [HACK] !\n")
+    def _map_params_into_terms(self) -> dict:
+        """
+        PUBMED only has one field to upload the search-string, called "term".
+        This method iterate on the query params that can be mapped and unify them on the
+        required term. If for example the input query_params are:
+            --content 'something' --title "star" --abstract "\"especific words\""
+        With this definition of the mapping dictionary:
+            self.dictionary {'content': 'term', 'title': ':[Title]->term', 'abstract': ':[Abstract]->term'}
+        The resulting query_params will have this content on param 'term':
+            query_params { ..., 'term': 'something AND star[Title] AND "especific words"[Abstract]
+        """
+        pop_list = []
+        # Init a dict to save any change on the terms. The key will be the term destination.
+        # The value will be a list grouping the new term with their tag, ie: new term[tag]
+        term_params_mapper = dict()
+        # Search for the params that have to be mapped in other term
+        for mapping_param in self.query_params:
+            if mapping_param.startswith(':'):
+                # Cut the indicator ':' and get the search tag and the term where it has to be mapped
+                tag, dest_term = mapping_param[1:].split('->')
+                if dest_term not in term_params_mapper:
+                    # Init the mapper for this term starting with the original content (if exist)
+                    term_params_mapper[dest_term] = list()
+                    original_term = self.query_params.get(dest_term)
+                    if original_term:
+                        term_params_mapper[dest_term].append(original_term)
+                # Append the required term to map for this destination term
+                term_params_mapper[dest_term].append( self.query_params.get(mapping_param) + tag )
+                self.logger.info('Mapping {{{}}} tagged term in \"{}\"'.
+                                 format(term_params_mapper[dest_term][-1], dest_term) )
+                pop_list.append( mapping_param )
+        # Delete those terms already mapped in others
+        for param in pop_list:
+            self.query_params.pop( param )
+        # Override or add the mapped terms
+        for mapped_term in term_params_mapper:
+            self.query_params[mapped_term] = ' AND '.join( term_params_mapper.get(mapped_term) )
+        #self.logger.info("\nQuery_params: " + str(self.query_params) + "\n")

--- a/repos/pubmed_def.py
+++ b/repos/pubmed_def.py
@@ -50,13 +50,16 @@ class pubmed(abc_def.repo):
 
 
     def build_dictionary(self):
-        self.dictionary['default'] = 'term'
+        self.dictionary['content'] = 'term'
         self.dictionary['apikey'] = 'api_key'
         self.dictionary['title'] = 'title'
         self.dictionary['from_year'] = 'mindate'
-        self.dictionary['end_year'] = 'maxdate'
+        self.dictionary['to_year'] = 'maxdate'
         self.dictionary['max_records_per_page'] = 'retmax'
         self.dictionary['first_index'] = 'retstart'
+        self.dictionary['abstract'] = 'term'    # HACK
+        self.dictionary['keyword'] = 'term'     # HACK
+        self.dictionary['query'] = 'term'       # HACK
 
 
     def search(self):
@@ -85,7 +88,6 @@ class pubmed(abc_def.repo):
             pub_year = date_format(summ[art]['pubdate'])
             self.add_to_dataframe( summ[art]['title'], pub_year )
             pub_year_array.append( pub_year )
-        self.export_csv()
         return self.build_report(pub_year_array)
 
 
@@ -135,3 +137,7 @@ class pubmed(abc_def.repo):
             print( exc )
             return None
         return result
+
+
+    def parse_query(self, query: str) -> str:
+        self.logger.warning( "\n CUIDADO QUE pubmed.parse_query( ) NO ESTA IMPLEMENTADO pero si en [HACK] !\n")

--- a/repos/scopus_def.py
+++ b/repos/scopus_def.py
@@ -83,6 +83,7 @@ class scopus(abc_def.repo):
             # TODO: contemplar que pasa si la busqueda no produce resultados o si se alcanza el limite diario
             total_records_count = ans.json()['search-results']['opensearch:totalResults']
 
+        pub_year_array = []
         for art in range(int(total_records_count)):
             if art and art%records_per_page == 0:
                 self.add_query_param(str(art), 'first_index')
@@ -90,6 +91,8 @@ class scopus(abc_def.repo):
                 self.logger.debug(ans.url)
             # print("Debug:" + str(art) + " of " + str(ans.json()['total_records']))
             # print(' - ' + ans.json()['articles'][art%records_per_page]['title'])
-            self.add_to_dataframe(ans.json()['search-results']['entry'][art%records_per_page]['dc:title'],
-                                  ans.json()['search-results']['entry'][art%records_per_page]['prism:coverDate'])
+            pub_year = ans.json()['search-results']['entry'][art%records_per_page]['prism:coverDate']
+            self.add_to_dataframe(ans.json()['search-results']['entry'][art%records_per_page]['dc:title'], pub_year)
+            pub_year_array.append( pub_year )
         self.export_csv()
+        return self.build_report(pub_year_array)

--- a/repos/scopus_def.py
+++ b/repos/scopus_def.py
@@ -94,5 +94,4 @@ class scopus(abc_def.repo):
             pub_year = ans.json()['search-results']['entry'][art%records_per_page]['prism:coverDate']
             self.add_to_dataframe(ans.json()['search-results']['entry'][art%records_per_page]['dc:title'], pub_year)
             pub_year_array.append( pub_year )
-        self.export_csv()
         return self.build_report(pub_year_array)


### PR DESCRIPTION
Cada búsqueda se registra en el archivo `results\historic.csv`.
Los campos son:
- ID (fecha en formato entero con 2 caracteres numéricos por campo)
- Los contadores de resultados en cada repositorio, antecedidos por un totalizador.
- El intervalo de busqueda
- Tres divisiones temporales del intervalo anterior para mostrar la distribución temporal de los artículos encontrados
-  Los parámetros que generaron dicha búsqueda, para poder volver a ejecutarla a futuro.

Para poder recuperar las busquedas pasadas hay diferentes opciones:
- **Get_by_id**: Return the historic register by its ID (numeric)
- **Get_previous**: Return the historic register that was searched `index` times ago. The value of `index` must be greater or equal to 0, lower than 1000
- **Get_by_index**: Return the historic register with the index counting from the beginning. The value of `index` must be negative.
- **Get_by_matching**: Return the historic register whose fields match with the given argument. If `field_names` argument is passed it only search on that field/s. If not, the search secuence will start by "Tags" and "Search Params" fields, and then others.
- **Get_by_filter**: Receive a filter patrón for a dataFrame. Use Filter_date method to search between dates